### PR TITLE
Add 1-based numeric selection for secrets (index-based lookup from pwm ls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,32 @@ pwm rm my_secret
 pwm --help
 ```
 
+### Index Selection
+
+You can also select secrets by numeric index instead of typing the full name. Run `pwm ls` to see a numbered tree (indices are 1-based and oldest secrets have lower numbers):
+
+```bash
+./pwm ls
+# /home/username/.pwm
+# ├── {1} old_secret
+# ├── {2} work/github
+# └── {3} personal/email
+```
+
+Use the index in any command that accepts a secret name. For example:
+
+```bash
+# Show secret with index 2 (same as `pwm "work/github"`)
+pwm 2
+
+# Copy password using index
+pwm cp 2
+
+# Remove using index
+pwm rm 2
+```
+
+
 ### Command Reference
 
 #### `pwm create <secret_name>`

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -12,14 +12,20 @@ import (
 
 // cpCmd represents the cp command
 var cpCmd = &cobra.Command{
-	Use:   "cp",
-	Short: "Copies the password of the specified secret to the clipboard.",
+	Use:   "cp <name|index>",
+	Short: "Copies the password of the specified secret (name or index) to the clipboard.",
 	Run: func(cmd *cobra.Command, args []string) {
 		switch len(args) {
 		case 0:
 			fmt.Println(cmd.UsageString())
 		case 1:
-			err := CopySecret(args[0])
+			name, err := resolveSecretArg(args[0])
+			if err != nil {
+				helpers.PrintError(err.Error())
+				return
+			}
+
+			err = CopySecret(name)
 			if err != nil {
 				helpers.PrintError(err.Error())
 			}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -11,10 +11,10 @@ import (
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "Lists all secrets located in the default location.",
+	Short: "Lists all secrets located in the default location (prints numeric indices).",
 	Run: func(cmd *cobra.Command, args []string) {
 		helpers.PrintInfo(storageLocation)
-		err := ListSecrets(storageLocation, 0)
+		err := ListSecretsNumbered(storageLocation, 0)
 		if err != nil {
 			helpers.PrintError(err.Error())
 		}

--- a/cmd/pwm.go
+++ b/cmd/pwm.go
@@ -5,10 +5,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/SpyrosMoux/pwm/internal/helpers"
 	"github.com/SpyrosMoux/pwm/internal/models"
@@ -130,6 +134,106 @@ func GetSecret(secret string) (decryptedSecret string, err error) {
 	return jsonSecret.String(), nil
 }
 
+// resolveSecretArg accepts either a secret name or a 1-based index string
+// and returns the resolved secret filename.
+func resolveSecretArg(arg string) (string, error) {
+	// try parse as integer index
+	idx, err := strconv.Atoi(arg)
+	if err != nil {
+		// not an integer, assume it's a name (possibly with subdir)
+		return arg, nil
+	}
+
+	if idx <= 0 {
+		return "", errors.New("index must be >= 1")
+	}
+
+	files, err := getFilesSortedByModTime(storageLocation)
+	if err != nil {
+		return "", err
+	}
+
+	if len(files) == 0 {
+		return "", errors.New("no secrets available")
+	}
+
+	if idx > len(files) {
+		return "", errors.New("index out of range")
+	}
+
+	return files[idx-1], nil
+}
+
+// collectFiles walks the storage directory and returns a slice of file paths
+// relative to the root. Directories are skipped.
+func collectFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// getFilesSortedByModTime returns a list of files (relative paths) under root
+// sorted by modification time ascending (oldest first). If mod times are equal
+// it falls back to lexical order.
+func getFilesSortedByModTime(root string) ([]string, error) {
+	type fileEntry struct {
+		rel     string
+		modTime time.Time
+	}
+
+	var entries []fileEntry
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, fileEntry{rel: rel, modTime: info.ModTime()})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].rel < entries[j].rel
+		}
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+
+	var files []string
+	for _, e := range entries {
+		files = append(files, e.rel)
+	}
+	return files, nil
+}
+
 func RemoveSecret(secret string) error {
 	_, err := os.Stat(storageLocation + "/" + secret)
 	if err != nil {
@@ -142,6 +246,109 @@ func RemoveSecret(secret string) error {
 	}
 
 	return nil
+}
+
+// ListSecretsNumbered prints a tree with numeric indices for files.
+// Indices correspond to the sorted list used by resolveSecretArg.
+func ListSecretsNumbered(root string, level int) error {
+	files, err := getFilesSortedByModTime(root)
+	if err != nil {
+		return err
+	}
+
+	indexMap := make(map[string]int)
+	for i, f := range files {
+		indexMap[f] = i + 1
+	}
+
+	// Build dirMin map: smallest index for files under each directory
+	dirMin := make(map[string]int)
+	const maxInt = int(^uint(0) >> 1)
+	dirMin["."] = maxInt
+	for rel, idx := range indexMap {
+		if idx < dirMin["."] {
+			dirMin["."] = idx
+		}
+		dir := filepath.Dir(rel)
+		for dir != "." && dir != string(filepath.Separator) && dir != "" {
+			cur, ok := dirMin[dir]
+			if !ok || idx < cur {
+				dirMin[dir] = idx
+			}
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	var printTree func(path string, level int) error
+	printTree = func(path string, level int) error {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return err
+		}
+
+		type node struct {
+			entry os.DirEntry
+			key   int
+		}
+		nodes := make([]node, 0, len(entries))
+		for _, entry := range entries {
+			if entry.IsDir() {
+				relDir, _ := filepath.Rel(root, filepath.Join(path, entry.Name()))
+				key := dirMin[relDir]
+				if key == 0 {
+					key = maxInt
+				}
+				nodes = append(nodes, node{entry: entry, key: key})
+			} else {
+				relFile, _ := filepath.Rel(root, filepath.Join(path, entry.Name()))
+				key := indexMap[relFile]
+				if key == 0 {
+					key = maxInt
+				}
+				nodes = append(nodes, node{entry: entry, key: key})
+			}
+		}
+
+		sort.Slice(nodes, func(i, j int) bool {
+			if nodes[i].key == nodes[j].key {
+				return nodes[i].entry.Name() < nodes[j].entry.Name()
+			}
+			return nodes[i].key < nodes[j].key
+		})
+
+		for i, n := range nodes {
+			entry := n.entry
+			prefix := strings.Repeat("│   ", level)
+			isLast := i == len(nodes)-1
+			connector := "├── "
+			if isLast {
+				connector = "└── "
+			}
+
+			if entry.IsDir() {
+				fmt.Printf("%s%s%s\n", prefix, connector, entry.Name())
+				err := printTree(filepath.Join(path, entry.Name()), level+1)
+				if err != nil {
+					return err
+				}
+			} else {
+				rel, err := filepath.Rel(root, filepath.Join(path, entry.Name()))
+				if err != nil {
+					return err
+				}
+				idx := indexMap[rel]
+				if idx > 0 {
+					fmt.Printf("%s%s{%d} %s\n", prefix, connector, idx, entry.Name())
+				} else {
+					fmt.Printf("%s%s%s\n", prefix, connector, entry.Name())
+				}
+			}
+		}
+
+		return nil
+	}
+
+	return printTree(root, level)
 }
 
 func CopySecret(secretName string) error {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -12,16 +12,22 @@ import (
 
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
-	Use:   "rm <your_secret>",
-	Short: "Removes a secret",
+	Use:   "rm <name|index>",
+	Short: "Removes a secret by name or numeric index (from `pwm ls`)",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		err := RemoveSecret(args[0])
+		name, err := resolveSecretArg(args[0])
+		if err != nil {
+			helpers.PrintError(err.Error())
+			return
+		}
+
+		err = RemoveSecret(name)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		helpers.PrintInfo("Removed secret: " + args[0])
+		helpers.PrintInfo("Removed secret: " + name)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "pwm",
 	Short:   "A simple password management tool",
-	Example: "pwm <my_secret>  Will print the decrypted secret",
+	Example: "pwm <my_secret|index>  Will print the decrypted secret (index from `pwm ls`)",
 	Args:    cobra.MinimumNArgs(0),
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
@@ -47,9 +47,16 @@ var rootCmd = &cobra.Command{
 			cmd.HelpFunc()(cmd, args)
 			os.Exit(0)
 		case 1:
-			secret, err := GetSecret(args[0])
+			name, err := resolveSecretArg(args[0])
 			if err != nil {
 				helpers.PrintError(err.Error())
+				os.Exit(1)
+			}
+
+			secret, err := GetSecret(name)
+			if err != nil {
+				helpers.PrintError(err.Error())
+				os.Exit(1)
 			}
 			helpers.PrintInfo(secret)
 			os.Exit(0)


### PR DESCRIPTION
## Summary

- Add 1-based numeric selection for secrets so users can reference secrets by index (from `pwm ls`) instead of typing full names.
- `pwm <index>` behaves the same as `pwm <name>`.

## What this changes

- Adds an index resolver and recursive file collection so indices map to a deterministic ordering.
- Prints numbered tree output in `pwm ls` showing `{n}` next to each secret file in the same order used by the resolver.
- Uses oldest-first ordering (mod-time ascending) so newly-created secrets append to the bottom and indices remain stable over time.
- Accepts numeric indices in:
  - root invocation (`pwm <index>`)
  - subcommands that take a secret: `cp` and `rm`
- Updates command help strings and README with index usage examples.

## Files modified

- `cmd/pwm.go`
- `cmd/root.go`
- `cmd/ls.go`
- `cmd/cp.go`
- `cmd/rm.go`
- `README.md`

## Behavior / examples

### Show numbered tree

```bash
pwm ls
```
Example output:

```plaintext
/Users/<user>pwm
├── {1} test1
├── {2} test2
├── {3} test3
└── {4} test4
```

### Retrieve by index or name (equivalent)

```bash
pwm 2
pwm test2
```

### Copy or remove by index

```bash
pwm cp 3
pwm rm 4
```